### PR TITLE
Add public to methods which should be accessible

### DIFF
--- a/Expectation.podspec
+++ b/Expectation.podspec
@@ -14,9 +14,11 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "8.0"
 
-  s.module_name  = "Expectation"
-  s.source       = { git: "https://github.com/ollieatkinson/Expectation.git", tag: "0.0.2" }
-  s.source_files = "Expectation/**/*.swift"
-  s.frameworks   = [ "Foundation", "XCTest" ]
+  s.module_name         = "Expectation"
+  s.source              = { git: "https://github.com/ollieatkinson/Expectation.git", tag: "0.0.2" }
+  s.source_files        = "Expectation/**/*.{swift,h,m}"
+  s.frameworks          = [ "Foundation" ]
+  s.weak_framework      = "XCTest"
+  s.pod_target_xcconfig = { ENABLE_BITCODE: 'NO', OTHER_LDFLAGS: '-weak-lswiftXCTest', FRAMEWORK_SEARCH_PATHS: '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
   
 end

--- a/Expectation.xcodeproj/xcshareddata/xcschemes/Expectation.xcscheme
+++ b/Expectation.xcodeproj/xcshareddata/xcschemes/Expectation.xcscheme
@@ -60,7 +60,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/Expectation/Expectation.h
+++ b/Expectation/Expectation.h
@@ -6,14 +6,7 @@
 //  Copyright © 2016 Oliver. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import Foundation;
 
-//! Project version number for Expectation.
 FOUNDATION_EXPORT double ExpectationVersionNumber;
-
-//! Project version string for Expectation.
 FOUNDATION_EXPORT const unsigned char ExpectationVersionString[];
-
-// In this header, you should import all the public headers of your framework using statements like #import <Expectation/PublicHeader.h>
-
-

--- a/Expectation/Source/Expectation.swift
+++ b/Expectation/Source/Expectation.swift
@@ -42,12 +42,12 @@ public class Expectation<T> {
     description = "expect(\(expect == nil ? "nil" : "\(expect!)"))"
   }
   
-  var to: Expectation {
+  public var to: Expectation {
     description += ".to"
     return self
   }
   
-  var toNot: Expectation {
+  public var toNot: Expectation {
     
     description += ".toNot"
     invert       = !invert
@@ -55,7 +55,7 @@ public class Expectation<T> {
     return self
   }
   
-  var notTo: Expectation {
+  public var notTo: Expectation {
     
     description += ".notTo"
     invert       = !invert

--- a/Expectation/Source/Matchers/Expectation+BeCloseTo.swift
+++ b/Expectation/Source/Matchers/Expectation+BeCloseTo.swift
@@ -8,13 +8,13 @@
 
 import CoreGraphics
 
-protocol DoubleConvertible {
+public protocol DoubleConvertible {
   var doubleValue: Double { get }
 }
 
 extension Double: DoubleConvertible {
   
-  var doubleValue: Double {
+  public var doubleValue: Double {
     return self
   }
   
@@ -22,15 +22,7 @@ extension Double: DoubleConvertible {
 
 extension Float: DoubleConvertible {
   
-  var doubleValue: Double {
-    return Double(self)
-  }
-  
-}
-
-extension Float80: DoubleConvertible {
-  
-  var doubleValue: Double {
+  public var doubleValue: Double {
     return Double(self)
   }
   
@@ -38,15 +30,15 @@ extension Float80: DoubleConvertible {
 
 extension CGFloat: DoubleConvertible {
   
-  var doubleValue: Double {
+  public var doubleValue: Double {
     return Double(self)
   }
   
 }
 
-extension Expectation where T: DoubleConvertible {
+public extension Expectation where T: DoubleConvertible {
   
-  func beCloseTo(other: T, within: T, description: String = "") {
+  public func beCloseTo(other: T, within: T, description: String = "") {
     
     guard let expect = expect else {
       fail(self.description(__FUNCTION__, other, description))

--- a/Expectation/Source/Matchers/Expectation+BeDynamicType.swift
+++ b/Expectation/Source/Matchers/Expectation+BeDynamicType.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2016 Oliver. All rights reserved.
 //
 
-extension Expectation {
+public extension Expectation {
   
-  func beDynamicType<U>(other: U.Type, _ description: String = "") {
+  public func beDynamicType<U>(other: U.Type, _ description: String = "") {
     assertTrue(expect.dynamicType == other, self.description(__FUNCTION__, other, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeEmpty.swift
+++ b/Expectation/Source/Matchers/Expectation+BeEmpty.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2016 Oliver. All rights reserved.
 //
 
-extension Expectation where T: CollectionType {
+public extension Expectation where T: CollectionType {
   
-  func beEmpty(description: String = "") {
+  public func beEmpty(description: String = "") {
     assertTrue(expect?.isEmpty ?? false, self.description(__FUNCTION__, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeFalse.swift
+++ b/Expectation/Source/Matchers/Expectation+BeFalse.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Equatable, T: BooleanLiteralConvertible {
+public extension Expectation where T: Equatable, T: BooleanLiteralConvertible {
 
-  func beFalse(description: String = "") {
+  public func beFalse(description: String = "") {
     assertTrue(expect == false, self.description(__FUNCTION__, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeGreaterThan.swift
+++ b/Expectation/Source/Matchers/Expectation+BeGreaterThan.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Comparable {
+public extension Expectation where T: Comparable {
 
-  func beGreaterThan(other: T, _ description: String = "") {
+  public func beGreaterThan(other: T, _ description: String = "") {
     assertTrue(expect > other, self.description(__FUNCTION__, other, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeGreaterThanOrEqualTo.swift
+++ b/Expectation/Source/Matchers/Expectation+BeGreaterThanOrEqualTo.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Comparable {
+public extension Expectation where T: Comparable {
   
-  func beGreaterThanOrEqualTo(other: T, _ description: String = "") {
+  public func beGreaterThanOrEqualTo(other: T, _ description: String = "") {
     assertTrue(expect >= other, self.description(__FUNCTION__, other, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeIdenticalTo.swift
+++ b/Expectation/Source/Matchers/Expectation+BeIdenticalTo.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: AnyObject {
+public extension Expectation where T: AnyObject {
   
-  func beIdenticalTo(other: T, _ description: String = "") {
+  public func beIdenticalTo(other: T, _ description: String = "") {
     assertTrue(expect === other, self.description(__FUNCTION__, other, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeLessThan.swift
+++ b/Expectation/Source/Matchers/Expectation+BeLessThan.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Comparable {
+public extension Expectation where T: Comparable {
   
-  func beLessThan(other: T, _ description: String = "") {
+  public func beLessThan(other: T, _ description: String = "") {
     assertTrue(expect < other, self.description(__FUNCTION__, other, description))
   }
 

--- a/Expectation/Source/Matchers/Expectation+BeLessThanOrEqualTo.swift
+++ b/Expectation/Source/Matchers/Expectation+BeLessThanOrEqualTo.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Comparable {
+public extension Expectation where T: Comparable {
 
-  func beLessThanOrEqualTo(other: T, _ description: String = "") {
+  public func beLessThanOrEqualTo(other: T, _ description: String = "") {
     assertTrue(expect <= other, self.description(__FUNCTION__, other, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeNil.swift
+++ b/Expectation/Source/Matchers/Expectation+BeNil.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation {
+public extension Expectation {
   
-  func beNil(description: String = "") {
+  public func beNil(description: String = "") {
     assertNil(expect, self.description(__FUNCTION__, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+BeTrue.swift
+++ b/Expectation/Source/Matchers/Expectation+BeTrue.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Equatable, T: BooleanLiteralConvertible {
+public extension Expectation where T: Equatable, T: BooleanLiteralConvertible {
   
-  func beTrue(description: String = "") {
+  public func beTrue(description: String = "") {
     assertTrue(expect == true, self.description(__FUNCTION__, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+ConformTo.swift
+++ b/Expectation/Source/Matchers/Expectation+ConformTo.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension Expectation where T: NSObjectProtocol {
+public extension Expectation where T: NSObjectProtocol {
 
-  func conformTo(aProtocol: Protocol, _ description: String = "") {
+  public func conformTo(aProtocol: Protocol, _ description: String = "") {
     assertTrue(expect?.conformsToProtocol(aProtocol) ?? false, self.description(__FUNCTION__, aProtocol, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+Contain.swift
+++ b/Expectation/Source/Matchers/Expectation+Contain.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: CollectionType, T.Generator.Element: Equatable {
+public extension Expectation where T: CollectionType, T.Generator.Element: Equatable {
 
-  func contain(element: T.Generator.Element, _ description: String = "") {
+  public func contain(element: T.Generator.Element, _ description: String = "") {
     assertFalse(expect?.indexOf(element) == nil, self.description(__FUNCTION__, element, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+Equal.swift
+++ b/Expectation/Source/Matchers/Expectation+Equal.swift
@@ -6,17 +6,17 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: Equatable {
+public extension Expectation where T: Equatable {
   
-  func equal(other: T, _ description: String = "") {
+  public func equal(other: T, _ description: String = "") {
     assertTrue(expect == other, self.description(__FUNCTION__, other, description))
   }
   
 }
 
-extension Expectation where T: CollectionType, T.Generator.Element: Equatable {
+public extension Expectation where T: CollectionType, T.Generator.Element: Equatable {
   
-  func equal(other: T, _ description: String = "") {
+  public func equal(other: T, _ description: String = "") {
     
     if let expect = expect {
       assertTrue(Array(expect) == Array(other), self.description(__FUNCTION__, other, description))

--- a/Expectation/Source/Matchers/Expectation+HaveCountOf.swift
+++ b/Expectation/Source/Matchers/Expectation+HaveCountOf.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2016 Oliver. All rights reserved.
 //
 
-extension Expectation where T: CollectionType {
+public extension Expectation where T: CollectionType {
   
-  func haveCountOf(count: T.Index.Distance, description: String = "") {
+  public func haveCountOf(count: T.Index.Distance, description: String = "") {
     assertTrue(expect?.count == count, self.description(__FUNCTION__, count, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+HavePrefix.swift
+++ b/Expectation/Source/Matchers/Expectation+HavePrefix.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: StringLiteralConvertible {
+public extension Expectation where T: StringLiteralConvertible {
   
-  func havePrefix(other: T, _ description: String = "") {
+  public func havePrefix(other: T, _ description: String = "") {
     
     guard let expect = expect else {
       fail(self.description(__FUNCTION__, other, description))

--- a/Expectation/Source/Matchers/Expectation+HaveSuffix.swift
+++ b/Expectation/Source/Matchers/Expectation+HaveSuffix.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2015 Oliver. All rights reserved.
 //
 
-extension Expectation where T: StringLiteralConvertible {
+public extension Expectation where T: StringLiteralConvertible {
   
-  func haveSuffix(other: T, _ description: String = "") {
+  public func haveSuffix(other: T, _ description: String = "") {
     
     guard let expect = expect else {
       fail(self.description(__FUNCTION__, other, description))

--- a/Expectation/Source/Matchers/Expectation+RespondTo.swift
+++ b/Expectation/Source/Matchers/Expectation+RespondTo.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension Expectation where T: NSObjectProtocol {
+public extension Expectation where T: NSObjectProtocol {
   
-  func respondTo(selector: Selector, _ description: String = "") {
+  public func respondTo(selector: Selector, _ description: String = "") {
     assertTrue(expect?.respondsToSelector(selector) ?? false, self.description(__FUNCTION__, selector, description))
   }
   

--- a/Expectation/Source/Matchers/Expectation+beKindOfClass.swift
+++ b/Expectation/Source/Matchers/Expectation+beKindOfClass.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension Expectation where T: NSObjectProtocol {
+public extension Expectation where T: NSObjectProtocol {
   
-  func beKindOfClass(klass: AnyClass, _ description: String = "") {
+  public func beKindOfClass(klass: AnyClass, _ description: String = "") {
     
     guard let expect = expect else {
       fail(self.description(__FUNCTION__, klass, description))

--- a/Tests/Example.swift
+++ b/Tests/Example.swift
@@ -202,9 +202,6 @@ class Example: XCTestCase {
     expect(CGFloat(1.2)).to.beCloseTo(1, within: 0.3)
     expect(CGFloat(1.2)).toNot.beCloseTo(1, within: 0.1)
     
-    expect(Float80(1.2)).to.beCloseTo(1, within: 0.2)
-    expect(Float80(1.2)).toNot.beCloseTo(1, within: 0.1)
-    
     let expectationShouldFail = expectationWithDescription("should fail beCloseTo")
     
     let float: Float? = nil


### PR DESCRIPTION
Why:
Methods were not visible through the interface, we need to declare them
public so when it is installed through cocoapods we can use them.

This change addresses the need by:
Declare extensions and functions public.
